### PR TITLE
Rename crate from mjlog-parser to tenhou-log-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,25 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mjlog-parser"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "encoding_rs",
- "env_logger",
- "flate2",
- "log",
- "percent-encoding",
- "quick-xml",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "uuid",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +455,25 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tenhou-log-parser"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "encoding_rs",
+ "env_logger",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mjlog-parser"
+name = "tenhou-log-parser"
 version = "0.1.0"
 edition = "2021"
 authors = ["Seiya Sakata"]
@@ -7,7 +7,7 @@ description = "A parser for Tenhou mjlog files to JSON conversion"
 license = "MIT"
 
 [[bin]]
-name = "mjlog-parser"
+name = "tenhou-log-parser"
 path = "src/main.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mjlog-parser
+# tenhou-log-parser
 
 A high-performance parser for Tenhou (天鳳) mahjong game logs written in Rust.
 
@@ -16,8 +16,8 @@ A high-performance parser for Tenhou (天鳳) mahjong game logs written in Rust.
 ### From source
 
 ```bash
-git clone https://github.com/yourusername/mjlog-parser
-cd mjlog-parser
+git clone https://github.com/yourusername/tenhou-log-parser
+cd tenhou-log-parser
 cargo build --release
 ```
 
@@ -27,19 +27,19 @@ cargo build --release
 
 ```bash
 # Parse and output to stdout
-mjlog-parser input.mjlog --stream
+tenhou-log-parser input.mjlog --stream
 
 # Parse and save to file
-mjlog-parser input.mjlog -o output.json
+tenhou-log-parser input.mjlog -o output.json
 
 # Verbose mode
-mjlog-parser input.mjlog --stream --verbose
+tenhou-log-parser input.mjlog --stream --verbose
 ```
 
 ### Library
 
 ```rust
-use mjlog_parser::{parse_file, ParserOptions};
+use tenhou_log_parser::{parse_file, ParserOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let options = ParserOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use log::{error, info};
 
-use mjlog_parser::{parse_file, parse_stream, ParserOptions};
+use tenhou_log_parser::{parse_file, parse_stream, ParserOptions};
 
 #[derive(Parser)]
-#[command(name = "mjlog-parser")]
+#[command(name = "tenhou-log-parser")]
 #[command(about = "A parser for Tenhou mjlog files to JSON conversion")]
 #[command(version)]
 struct Args {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -20,7 +20,7 @@ pub enum TileType {
 ///
 /// # Examples
 /// ```
-/// use mjlog_parser::tile_id_to_string;
+/// use tenhou_log_parser::tile_id_to_string;
 /// assert_eq!(tile_id_to_string(0), "1m");
 /// assert_eq!(tile_id_to_string(31 * 4), "white");
 /// ```
@@ -46,7 +46,7 @@ pub fn tile_id_to_string(id: u32) -> Cow<'static, str> {
 ///
 /// # Examples
 /// ```
-/// use mjlog_parser::tile_string_to_id;
+/// use tenhou_log_parser::tile_string_to_id;
 /// assert_eq!(tile_string_to_id("1m").unwrap(), 0);
 /// assert_eq!(tile_string_to_id("white").unwrap(), 124);
 /// ```

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -3,7 +3,7 @@ use tempfile::NamedTempFile;
 
 #[test]
 fn test_e2e_sample_xml() {
-    let output = Command::new(env!("CARGO_BIN_EXE_mjlog-parser"))
+    let output = Command::new(env!("CARGO_BIN_EXE_tenhou-log-parser"))
         .args(&["tests/data/sample.xml", "--stream"])
         .output()
         .expect("Failed to execute command");
@@ -74,7 +74,7 @@ fn test_e2e_file_output() {
     let temp_output = NamedTempFile::new().unwrap();
     let output_path = temp_output.path().to_str().unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_mjlog-parser"))
+    let output = Command::new(env!("CARGO_BIN_EXE_tenhou-log-parser"))
         .args(&["tests/data/sample.xml", "-o", output_path, "-f"])
         .output()
         .expect("Failed to execute command");
@@ -98,7 +98,7 @@ fn test_e2e_file_output() {
 
 #[test]
 fn test_e2e_verbose_mode() {
-    let output = Command::new(env!("CARGO_BIN_EXE_mjlog-parser"))
+    let output = Command::new(env!("CARGO_BIN_EXE_tenhou-log-parser"))
         .args(&["tests/data/sample.xml", "--stream", "-v"])
         .output()
         .expect("Failed to execute command");
@@ -120,7 +120,7 @@ fn test_e2e_verbose_mode() {
 
 #[test]
 fn test_e2e_nonexistent_file() {
-    let output = Command::new(env!("CARGO_BIN_EXE_mjlog-parser"))
+    let output = Command::new(env!("CARGO_BIN_EXE_tenhou-log-parser"))
         .args(&["nonexistent.xml"])
         .output()
         .expect("Failed to execute command");
@@ -132,14 +132,14 @@ fn test_e2e_nonexistent_file() {
 
 #[test]
 fn test_e2e_help() {
-    let output = Command::new(env!("CARGO_BIN_EXE_mjlog-parser"))
+    let output = Command::new(env!("CARGO_BIN_EXE_tenhou-log-parser"))
         .args(&["--help"])
         .output()
         .expect("Failed to execute command");
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("mjlog-parser"));
+    assert!(stdout.contains("tenhou-log-parser"));
     assert!(stdout.contains("A parser for Tenhou mjlog files"));
     assert!(stdout.contains("--stream"));
     assert!(stdout.contains("--verbose"));
@@ -147,7 +147,7 @@ fn test_e2e_help() {
 
 #[test]
 fn test_e2e_version() {
-    let output = Command::new(env!("CARGO_BIN_EXE_mjlog-parser"))
+    let output = Command::new(env!("CARGO_BIN_EXE_tenhou-log-parser"))
         .args(&["--version"])
         .output()
         .expect("Failed to execute command");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
-use mjlog_parser::{parse_mjlog, ParserOutput};
 use std::io::Cursor;
 use std::process::Command;
 use tempfile::NamedTempFile;
+use tenhou_log_parser::{parse_mjlog, ParserOutput};
 
 mod helpers;
 use helpers::{complete_mjlog, minimal_mjlog, test_data_path};
@@ -46,7 +46,7 @@ fn test_cli_help_command() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("mjlog-parser"));
+    assert!(stdout.contains("tenhou-log-parser"));
     assert!(stdout.contains("A parser for Tenhou mjlog files"));
 }
 


### PR DESCRIPTION
## Summary
- Update Cargo.toml package and binary names to `tenhou-log-parser`
- Update README.md title and CLI usage examples
- Update all use statements in source code and tests
- Fix test assertions for renamed binary
- Ensure naming consistency across repository, crate, and documentation

## Changes Made
- [x] **Cargo.toml**: Changed package name and binary name
- [x] **README.md**: Updated title, installation instructions, and CLI examples
- [x] **Source Code**: Updated `use mjlog_parser` to `use tenhou_log_parser`
- [x] **Tests**: Updated all references and CLI test assertions
- [x] **Documentation**: Updated doc comments with correct crate name

## Test Plan
- [x] All unit tests pass (27 tests)
- [x] All integration tests pass (8 tests)  
- [x] All e2e tests pass (6 tests)
- [x] Doc tests pass (2 tests)
- [x] Binary compiles and runs correctly with new name

🤖 Generated with [Claude Code](https://claude.ai/code)